### PR TITLE
Fix console entries whitespace

### DIFF
--- a/src/app/webapp-common/experiments/dumb/experiment-log-info/experiment-log-info.component.scss
+++ b/src/app/webapp-common/experiments/dumb/experiment-log-info/experiment-log-info.component.scss
@@ -32,7 +32,7 @@
       color: #FFFFFF;
       height: 25px;
       padding: 5px 0 0 190px;
-      white-space: nowrap;
+      white-space: pre;
       border-bottom: 1px solid transparent;
     }
 


### PR DESCRIPTION
Hello, I would like to propose a change to keep the formatting of the logs, which is important for many things, some examples:

Before:
![image](https://user-images.githubusercontent.com/9201969/112295474-3bb99a80-8c94-11eb-9610-d2a8e7f0c750.png)
![image](https://user-images.githubusercontent.com/9201969/112295799-8804da80-8c94-11eb-8ecb-dab53ac9d578.png)
![image](https://user-images.githubusercontent.com/9201969/112296031-ca2e1c00-8c94-11eb-870a-bc20040ac3b6.png)


After:
![image](https://user-images.githubusercontent.com/9201969/112295437-32303280-8c94-11eb-95f4-639d8a3ccb1c.png)
![image](https://user-images.githubusercontent.com/9201969/112295838-9521c980-8c94-11eb-8383-aef0153e4e82.png)
![image](https://user-images.githubusercontent.com/9201969/112296084-d74b0b00-8c94-11eb-8fb5-6f45042ebd67.png)
