### PR TITLE
Update default pipeline example

### DIFF
--- a/src/app/webapp-common/pipelines/pipelines-page/pipelines-page.component.ts
+++ b/src/app/webapp-common/pipelines/pipelines-page/pipelines-page.component.ts
@@ -32,7 +32,8 @@ def step(size: int):
 @PipelineDecorator.pipeline(
     name='ingest',
     project='data processing',
-    version='0.1'
+    version='0.1',
+    pipeline_execution_queue="default"
 )
 def pipeline_logic(do_stuff: bool):
     if do_stuff:


### PR DESCRIPTION
Hello, as I pointed out in https://github.com/allegroai/clearml-web/issues/36, the default pipeline example fails to run remotely due to the pipeline_execution_queue not being specified to `default`. 

I looked at the `clearml` SDK `controller.py` code but I don't think I can make a call as to how the logic should be working, however there is also likely a fault in logic at this [line](https://github.com/allegroai/clearml/blob/master/clearml/automation/controller.py#L3777) since the value for `pipeline_execution_queue` is setting to `services` by default instead of None :/

Thank you!