### PR TITLE
Request bigger batches for console logs, helps searching

### DIFF
--- a/src/app/webapp-common/experiments/shared/common-experiments.const.ts
+++ b/src/app/webapp-common/experiments/shared/common-experiments.const.ts
@@ -51,7 +51,7 @@ export const TASK_TAGS = {
   HIDDEN: 'archived' as TaskTagsEnum
 };
 
-export const LOG_BATCH_SIZE = 100;
+export const LOG_BATCH_SIZE = 5000;
 
 export enum CustomColumnMode {
   Standard,

--- a/src/app/webapp-common/experiments/shared/common-experiments.const.ts
+++ b/src/app/webapp-common/experiments/shared/common-experiments.const.ts
@@ -51,7 +51,7 @@ export const TASK_TAGS = {
   HIDDEN: 'archived' as TaskTagsEnum
 };
 
-export const LOG_BATCH_SIZE = 5000;
+export const LOG_BATCH_SIZE = 1000;
 
 export enum CustomColumnMode {
   Standard,


### PR DESCRIPTION
Navigating consoles logs is a bit inefficient and searching is broken by lazy loaded messages, this commit does not solve this but helps a bit by requesting more messages at each request (current size does ~8kB brotli requests on my tests but I guess it depends on message length). 5000 is the default size for the backend: https://github.com/allegroai/clearml-server/blob/452f606889d069290f3786a8d07517ad2b472efa/apiserver/apimodels/events.py#L112C10-L112C10