### PR TITLE
Feature/arrows highlight

### DIFF
--- a/proxy.config.mjs
+++ b/proxy.config.mjs
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 
 const targets = [
-  'http://localhost:8081',     // 1
+ 'http://localhost:8008',     // 1
 ];
 
 const PROXY_CONFIG = {

--- a/src/app/webapp-common/pipelines-controller/pipeline-controller-info/pipeline-controller-info.component.html
+++ b/src/app/webapp-common/pipelines-controller/pipeline-controller-info/pipeline-controller-info.component.html
@@ -32,6 +32,7 @@
       <g
         *ngFor="let arrow of arrows; trackBy: trackArrows"
         [class.selected]="arrow.selected"
+        [class.outgoing]="arrow.outgoing"
       >
         <path [attr.d]="arrow.path" fill="none" stroke-width="2"></path>
         <polygon

--- a/src/app/webapp-common/pipelines-controller/pipeline-controller-info/pipeline-controller-info.component.html
+++ b/src/app/webapp-common/pipelines-controller/pipeline-controller-info/pipeline-controller-info.component.html
@@ -24,6 +24,7 @@
       ></sm-pipeline-controller-step>
     </div>
     <svg class="arrows"
+         [class.selected]="selectedEntity?.id"
          *ngIf="chartWidth"
          [attr.viewBox]="'0 0 ' + chartWidth + ' ' + (50 + 132 * dagModel?.length)"
          [style.width.px]="chartWidth"

--- a/src/app/webapp-common/pipelines-controller/pipeline-controller-info/pipeline-controller-info.component.scss
+++ b/src/app/webapp-common/pipelines-controller/pipeline-controller-info/pipeline-controller-info.component.scss
@@ -136,12 +136,16 @@ $log-header-height: 48px;
     left: 0;
     top: 0;
     pointer-events: none;
-    stroke: $blue-400;
-    fill: $blue-400;
+    stroke: $blue-800;
+    fill: $blue-800;
 
     .selected {
       stroke: $blue-200;
       fill: $blue-200;
+    }
+    .outgoing {
+      stroke: $blue-400;
+      fill: $blue-400;
     }
   }
 }

--- a/src/app/webapp-common/pipelines-controller/pipeline-controller-info/pipeline-controller-info.component.scss
+++ b/src/app/webapp-common/pipelines-controller/pipeline-controller-info/pipeline-controller-info.component.scss
@@ -136,16 +136,16 @@ $log-header-height: 48px;
     left: 0;
     top: 0;
     pointer-events: none;
-    stroke: $blue-800;
-    fill: $blue-800;
+    stroke: $blue-600;
+    fill: $blue-600;
 
     .selected {
       stroke: $blue-200;
       fill: $blue-200;
     }
     .outgoing {
-      stroke: $blue-400;
-      fill: $blue-400;
+      stroke: $blue-300;
+      fill: $blue-300;
     }
   }
 }

--- a/src/app/webapp-common/pipelines-controller/pipeline-controller-info/pipeline-controller-info.component.scss
+++ b/src/app/webapp-common/pipelines-controller/pipeline-controller-info/pipeline-controller-info.component.scss
@@ -136,9 +136,13 @@ $log-header-height: 48px;
     left: 0;
     top: 0;
     pointer-events: none;
-    stroke: $blue-600;
-    fill: $blue-600;
+    stroke: $blue-400;
+    fill: $blue-400;
 
+    &.selected {
+      stroke: $blue-600;
+      fill: $blue-600;
+    }
     .selected {
       stroke: $blue-200;
       fill: $blue-200;

--- a/src/app/webapp-common/pipelines-controller/pipeline-controller-info/pipeline-controller-info.component.ts
+++ b/src/app/webapp-common/pipelines-controller/pipeline-controller-info/pipeline-controller-info.component.ts
@@ -66,6 +66,8 @@ export interface Arrow {
   headTransform: string;
   selected: boolean;
   targetId: string;
+  outgoing?: boolean;
+  sourceId?: number;
 }
 
 export enum StatusOption {
@@ -315,6 +317,8 @@ export class PipelineControllerInfoComponent implements OnInit, AfterViewInit, O
               path: `M${sx} ${sy} C${c1x} ${c1y}, ${c2x} ${c2y}, ${ex} ${ey}`,
               headTransform: `translate(${ex},${ey}) rotate(${ae})`,
               selected: false,
+              outgoing: false,
+              sourceId: parentId,
               targetId: pipeLineItem.id
             });
           }
@@ -417,9 +421,11 @@ export class PipelineControllerInfoComponent implements OnInit, AfterViewInit, O
   }
 
   protected highlightArrows() {
-    this.arrows = this.arrows
-      ?.map(arrow => ({...arrow, selected: arrow.targetId === this.selectedEntity?.id}))
-      .sort((a, b) => a.selected && !b.selected ? 1 : -1);
+    this.arrows = this.arrows?.map(arrow => {
+      const isTarget = arrow.targetId === this.selectedEntity?.id;
+      const isSource = arrow.sourceId === this.selectedEntity?.stepId;
+      return {...arrow, selected: isTarget || isSource, outgoing: isSource};
+    }).sort((a, b) => (a.selected === b.selected) ? 0 : a.selected ? 1 : -1);
   }
 
   protected getTreeObject(task) {

--- a/src/app/webapp-common/pipelines-controller/pipeline-controller-info/pipeline-controller-info.component.ts
+++ b/src/app/webapp-common/pipelines-controller/pipeline-controller-info/pipeline-controller-info.component.ts
@@ -65,9 +65,9 @@ export interface Arrow {
   path2?: string;
   headTransform: string;
   selected: boolean;
-  targetId: string;
+  targetId: number;
+  sourceId: number;
   outgoing?: boolean;
-  sourceId?: number;
 }
 
 export enum StatusOption {
@@ -319,7 +319,7 @@ export class PipelineControllerInfoComponent implements OnInit, AfterViewInit, O
               selected: false,
               outgoing: false,
               sourceId: parentId,
-              targetId: pipeLineItem.id
+              targetId: pipeLineItem.stepId,
             });
           }
         }
@@ -422,7 +422,7 @@ export class PipelineControllerInfoComponent implements OnInit, AfterViewInit, O
 
   protected highlightArrows() {
     this.arrows = this.arrows?.map(arrow => {
-      const isTarget = arrow.targetId === this.selectedEntity?.id;
+      const isTarget = arrow.targetId === this.selectedEntity?.stepId;
       const isSource = arrow.sourceId === this.selectedEntity?.stepId;
       return {...arrow, selected: isTarget || isSource, outgoing: isSource};
     }).sort((a, b) => (a.selected === b.selected) ? 0 : a.selected ? 1 : -1);


### PR DESCRIPTION
Issue:
(a) Arrows only point _towards_ tasks in pipelines, not _away_ from them, making it pretty hard to trace dependencies by-eye for large pipelines.
(b) Inconsistent arrow ordering (nondeterministic: `.sort((a, b) => a.selected && !b.selected ? 1 : -1)`)
(c) Colors of unselected arrows do not have sufficient contrast with selected ones.
(d) Default proxy port should reflect default API backend port.

Proposed Solution:
(a) Trace target + source in order to highlight both types of arrows.
(b) small change
(c) small change (opinionated choices made. If anything the choice of unselected color may be too dark now... need to try it on a variety of screens)
(d) small change

Demo:
unselected before:
<img width="621" alt="image" src="https://github.com/allegroai/clearml-web/assets/40366263/8d081a8f-4138-404e-bda5-fe5bb36968e1">

unselected after:
<img width="810" alt="image" src="https://github.com/allegroai/clearml-web/assets/40366263/b0746bce-dc20-4288-8531-65e29364563a">

selected before:
<img width="603" alt="image" src="https://github.com/allegroai/clearml-web/assets/40366263/022a7d15-5902-4f2e-9be5-249506841219">

selected after:
<img width="741" alt="image" src="https://github.com/allegroai/clearml-web/assets/40366263/b0cdbadf-cb7f-4301-9d9e-13d6b2298dd9">


another example:
this output arrow was basically impossible to identify before: 
<img width="624" alt="image" src="https://github.com/allegroai/clearml-web/assets/40366263/ba8fbf24-14bd-4d0f-8341-204d6e74e2b4">

<img width="575" alt="image" src="https://github.com/allegroai/clearml-web/assets/40366263/e968b0eb-13ea-460f-9b72-c572746aa706">

so I can actually find the task associated with its destination

<img width="702" alt="image" src="https://github.com/allegroai/clearml-web/assets/40366263/f286a49a-27d1-40a7-b032-dcb38eb96fd3">

given that the rows are deterministic right now, I could technically highlight outgoing and incoming _with the same color_, but when there are a lot of arrows coming in or out, it becomes easier to tell which are input vs output if the colors differ.

The new "outgoing arrow" color is the old "unselected color" and the new "unselected color" is darker.

Feedback would be welcome / appreciated.
